### PR TITLE
Add ScheduledSet.available

### DIFF
--- a/redset/__init__.py
+++ b/redset/__init__.py
@@ -7,6 +7,6 @@ Simple redis-backed, distributed sorted sets.
 
 """
 
-__version__ = '0.5'
+__version__ = '0.5.1'
 
 from redset.sets import *

--- a/redset/sets.py
+++ b/redset/sets.py
@@ -404,6 +404,13 @@ class ScheduledSet(TimeSortedSet):
     def _get_next_item(self, with_score=False):
         return self._get_item(with_score=with_score)
 
+    def available(self):
+        """
+        The count of items with a score less than now.
+
+        """
+        return self.redis.zcount(self.name, '-inf', time.time())
+
 
 class _DefaultSerializer(Serializer):
 

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -498,6 +498,18 @@ class ScheduledSetTest(unittest.TestCase):
             5,
         )
 
+    def test_length_available(self):
+        for i in range(2):
+            self.ss.add(i, self.now + 50)
+
+        for i in range(3):
+            self.ss.add(i + 2, self.now - 50)
+
+        self.assertEquals(
+            self.ss.available(),
+            3,
+        )
+
     def test_contains(self):
         for i in range(5):
             self.ss.add(i)


### PR DESCRIPTION
Since a ScheduledSet won't give up items newer than `time.time()`, `len(my_scheduled_set)` isn't a useful reflection of "queue size right now." This adds an `available` method which returns the count of items that can currently be `pop`'d or `take`'d.